### PR TITLE
Z2LABEL should be used for converting index to atom symbol

### DIFF
--- a/src/fragmentation.py
+++ b/src/fragmentation.py
@@ -589,7 +589,7 @@ class Fragmentation(FragItConfig):
         if len(atoms) == 1:
             atom = self.mol.GetAtom(atoms[0])
             charge_lbl = charge_lbls[atom.GetFormalCharge()]
-            element = LABEL2Z[atom.GetAtomicNum()]
+            element = Z2LABEL[atom.GetAtomicNum()]
             return "{0:s}{1:s}".format(element, charge_lbl)
         else:
             for residue in openbabel.OBResidueIter( self.mol ):


### PR DESCRIPTION
Dear,
Thanks for sharing useful code. I tried to use fragit against PDB but got error.
I think Z2LABEL should be used to convert atom index to symbol.
Thanks,
Taka